### PR TITLE
moved github logo to the right, set wiki search autofocus

### DIFF
--- a/impressum.html
+++ b/impressum.html
@@ -50,7 +50,7 @@ Angaben der Quelle für verwendetes Bilder- und Grafikmaterial:<br/><a href="htt
                   <p>&copy; 2015 André Bach</p>
               </div>
               <div class="col-md-6 col-xs-6 col-lg-6">
-            <p class="text-muted"><a href="https://www.github.com/anba1994/nebelwandler"><img src="images/github.png" alt="github logo" height="70"></a></p>
+            <p class="text-muted pull-right"><a href="https://www.github.com/anba1994/nebelwandler"><img src="images/github.png" alt="github logo" height="70"></a></p>
             </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
             <p>&copy; 2015 André Bach</p>
         </div>
         <div class="col-md-6 col-xs-6 col-lg-6">
-      <p class="text-muted"><a href="https://www.github.com/anba1994/nebelwandler"><img src="images/github.png" alt="github logo" height="70"></a></p>
+      <p class="text-muted pull-right"><a href="https://www.github.com/anba1994/nebelwandler"><img src="images/github.png" alt="github logo" height="70"></a></p>
       </div>
         </div>
       </div>

--- a/wikisearch.html
+++ b/wikisearch.html
@@ -46,7 +46,7 @@
 				  <fieldset>
 				    <legend><h1>Wikipedia Suche</h1></legend>
 				    <label for="search-input"><h2>Bitte geben Sie hier ihren Suchbegriff ein.</h2></label><br/>
-				    <input type="text"   name="search-input" id="search-input" value=""/>
+				    <input autofocus type="text"   name="search-input" id="search-input" value=""/>
 				    <input type="submit" name="go" value="Artikel"/>
 				    <input type="submit" name="fulltext" value="Volltext" />
 				  </fieldset>
@@ -69,7 +69,7 @@
             <p>&copy; 2015 André Bach</p>
         </div>
         <div class="col-md-6 col-xs-6 col-lg-6">
-      <p class="text-muted"><a href="https://www.github.com/anba1994/nebelwandler"><img src="images/github.png" alt="github logo" height="70"></a></p>
+      <p class="text-muted pull-right"><a href="https://www.github.com/anba1994/nebelwandler"><img src="images/github.png" alt="github logo" height="70"></a></p>
       </div>
         </div>
       </div>


### PR DESCRIPTION
Hi Andre,
hab das GitHub Logo in deinem Footer nach rechts verschoben und den Autofocus in deiner Wiki-Suche auf das Textfeld gelegt.
